### PR TITLE
Close button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,13 +6,16 @@ import 'sidebar.dart';
 void main() => runApp(MaterialApp(
       debugShowCheckedModeBanner: false,
       home: Dashboard(),
-    ));
+      theme: ThemeData(
+        fontFamily: 'OpenSans'
+        )
+      )
+    );
 
 class Dashboard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        backgroundColor: todoLightGrey,
         appBar: PreferredSize(
             preferredSize: Size.fromHeight(80.0),
             child: ToDoAppBar(LogoName: 'assets/To_Do_Light.png')),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'style.dart';
-import 'sidebar.dart';
 import 'settings.dart';
+import 'sidebar.dart';
 
 void main() => runApp(MaterialApp(
       debugShowCheckedModeBanner: false,
@@ -66,7 +66,6 @@ class Dashboard extends StatelessWidget {
                       ButtonIcon: Icons.settings,
                       TextIcon: "Settings",
                       Route: Settings(),
-                      //TODO: Create page for this and remove default
                     ),
                   ],
                 ),

--- a/lib/settings.dart
+++ b/lib/settings.dart
@@ -59,7 +59,10 @@ class SetTimezone extends StatelessWidget {
     return Scaffold(
         appBar: PreferredSize(
             preferredSize: Size.fromHeight(80.0),
-            child: ToDoAppBar(LogoName: 'assets/To_Do_Light.png')),
+            child: ToDoAppBar(
+              LogoName: 'assets/To_Do_Light.png',
+              isSubPage: true,
+            )),
         drawer: Drawer(
           child: SideBar(),
         ),
@@ -96,7 +99,10 @@ class ManageDevices extends StatelessWidget {
     return Scaffold(
         appBar: PreferredSize(
             preferredSize: Size.fromHeight(80.0),
-            child: ToDoAppBar(LogoName: 'assets/To_Do_Light.png')),
+            child: ToDoAppBar(
+              LogoName: 'assets/To_Do_Light.png',
+              isSubPage: true,
+            )),
         drawer: Drawer(
           child: SideBar(),
         ),

--- a/lib/sidebar.dart
+++ b/lib/sidebar.dart
@@ -11,7 +11,6 @@ class SideBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: todoLightGrey,
       appBar: PreferredSize(
           preferredSize: Size.fromHeight(80.0),
           child: ToDoAppBar(LogoName: 'assets/To_Do_Light.png')),

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -45,7 +45,7 @@ class ToDoAppBar extends StatelessWidget {
                 padding: const EdgeInsets.fromLTRB(0, 12, 5, 0),
                 child: new IconButton(
                   icon: Icon(
-                    Icons.arrow_back,
+                    Icons.close,
                     color: todoLightGrey,
                     size: 40,
                   ),

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -11,10 +11,9 @@ Color todoLightGreen = Color(0xFFdce9e8);
 // Main App Bar for App
 class ToDoAppBar extends StatelessWidget {
   final String LogoName;
+  bool isSubPage;
 
-  const ToDoAppBar({
-    this.LogoName,
-  });
+  ToDoAppBar({this.LogoName, this.isSubPage = false});
 
   @override
   Widget build(BuildContext context) {
@@ -33,14 +32,28 @@ class ToDoAppBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         // Source: https://stackoverflow.com/questions/43981406/how-to-center-the-title-of-an-appbar
         children: [
-          //todo: COMMENT: Maybe text or image? both might be a little much
-          // Removed: Text('Home Page'),
           Padding(
             padding: const EdgeInsets.fromLTRB(0, 10, 0, 0),
             child: Image.asset(LogoName, fit: BoxFit.contain, height: 50),
           ),
         ],
       ),
+
+      actions: <Widget>[
+        isSubPage
+            ? Padding(
+                padding: const EdgeInsets.fromLTRB(0, 12, 5, 0),
+                child: new IconButton(
+                  icon: Icon(
+                    Icons.arrow_back,
+                    color: todoLightGrey,
+                    size: 40,
+                  ),
+                  onPressed: () => Navigator.of(context).pop(null),
+                ),
+              )
+            : Container(),
+      ],
 
       // https://stackoverflow.com/questions/59554348/how-can-i-change-drawer-icon-in-flutter
       leading: Builder(
@@ -161,7 +174,7 @@ class ListButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
         onTap: () {
-          Navigator.pushReplacement(
+          Navigator.push(
               context, MaterialPageRoute(builder: (context) => ListRoute));
         },
         leading: Icon(


### PR DESCRIPTION
When on a sub page (such as Time Zone in Settings) a close button will appear in the top right of the app bar. The close button should navigate you back to the previous page.

Added Boolean parameter isSubPage to app bar, pass true if you would like to display close button on your page. Note that I set it to default to false, so when you are not creating a sub page you don't have to pass it anything.